### PR TITLE
feat: add dark/light mode toggle with theme persistence 🌗

### DIFF
--- a/apps/frontend/src/Components/Navbar.jsx
+++ b/apps/frontend/src/Components/Navbar.jsx
@@ -6,6 +6,7 @@ import { removeUser } from "../utils/userSlice";
 import { removeFeed } from "../utils/feedSlice";
 import Avatar from "./Avatar";
 import ChatList from "./ChatList";
+import ThemeToggle from "./ThemeToggle"; // ⬅️ NEW
 
 const Navbar = () => {
 	const user = useSelector((store) => store.user);
@@ -68,6 +69,9 @@ const Navbar = () => {
 				<div className="navbar-end">
 					{user ? (
 						<div className="flex items-center gap-3">
+							{/* Theme Toggle */}
+							<ThemeToggle />
+
 							{/* Chat List */}
 							<ChatList />
 

--- a/apps/frontend/src/Components/ThemeToggle.jsx
+++ b/apps/frontend/src/Components/ThemeToggle.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { applyTheme, getInitialTheme } from "../utils/theme";
 
 const ThemeToggle = () => {

--- a/apps/frontend/src/Components/ThemeToggle.jsx
+++ b/apps/frontend/src/Components/ThemeToggle.jsx
@@ -1,12 +1,41 @@
 import { useEffect } from "react";
+import { applyTheme, getInitialTheme } from "../utils/theme";
+
+const THEME_KEY = "devtinder-theme";
 
 const ThemeToggle = () => {
-	// Force app theme to the design system (single dark theme)
+	const [theme, setTheme] = useState("light");
+
 	useEffect(() => {
-		document.documentElement.setAttribute("data-theme", "devtinderDark");
-		localStorage.setItem("theme", "devtinderDark");
+		const initial = getInitialTheme();
+		setTheme(initial);
 	}, []);
-	return null;
+
+	useEffect(() => {
+		applyTheme(theme);
+	}, [theme]);
+
+	const toggleTheme = () => {
+		setTheme((prev) => (prev === "light" ? "dark" : "light"));
+	};
+
+	return (
+		<button
+			onClick={toggleTheme}
+			className="btn btn-ghost btn-sm flex items-center gap-2"
+			aria-label="Toggle dark / light mode"
+		>
+			{theme === "dark" ? (
+				<>
+					🌙 <span className="hidden sm:inline">Dark</span>
+				</>
+			) : (
+				<>
+					☀️ <span className="hidden sm:inline">Light</span>
+				</>
+			)}
+		</button>
+	);
 };
 
 export default ThemeToggle;

--- a/apps/frontend/src/Components/ThemeToggle.jsx
+++ b/apps/frontend/src/Components/ThemeToggle.jsx
@@ -1,8 +1,6 @@
 import { useEffect } from "react";
 import { applyTheme, getInitialTheme } from "../utils/theme";
 
-const THEME_KEY = "devtinder-theme";
-
 const ThemeToggle = () => {
 	const [theme, setTheme] = useState("light");
 

--- a/apps/frontend/src/main.jsx
+++ b/apps/frontend/src/main.jsx
@@ -2,6 +2,11 @@ import { StrictMode, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { getInitialTheme, applyTheme } from "./utils/theme";
+
+// This makes sure your app doesn’t flash wrong theme on first load.
+const initialTheme = getInitialTheme();
+applyTheme(initialTheme);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/apps/frontend/src/utils/theme.js
+++ b/apps/frontend/src/utils/theme.js
@@ -1,0 +1,35 @@
+const THEME_KEY = "devtinder-theme";
+
+const getSystemTheme = () => {
+	if (typeof window === "undefined") return "light";
+
+	const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)")?.matches;
+	return prefersDark ? "dark" : "light";
+};
+
+export const getInitialTheme = () => {
+	if (typeof window === "undefined") return "light";
+
+	const stored = localStorage.getItem(THEME_KEY);
+	if (stored === "light" || stored === "dark") return stored;
+
+	return getSystemTheme();
+};
+
+export const applyTheme = (theme) => {
+	if (typeof document === "undefined") return;
+
+	const root = document.documentElement;
+
+	// For DaisyUI
+	root.setAttribute("data-theme", theme);
+
+	// Optional: also support Tailwind `dark:` utilities if you use them
+	if (theme === "dark") {
+		root.classList.add("dark");
+	} else {
+		root.classList.remove("dark");
+	}
+
+	localStorage.setItem(THEME_KEY, theme);
+};

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -2,6 +2,7 @@
 import daisyui from "daisyui";
 
 export default {
+	darkMode: "class",
 	content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
 	theme: {
 		extend: {


### PR DESCRIPTION
This PR adds a fully functional light/dark mode toggle to the DevTinder frontend.  
The toggle integrates with DaisyUI themes and persists the user's theme choice using localStorage.

### 🔧 What’s Included
- New `theme.js` utility for theme state management and initialization
- New `ThemeToggle` component added to the navbar
- App-level theme initialization to avoid UI flashing
- `Navbar.jsx` updated to include the toggle next to user actions

### 🎯 Why This Matters
- Enhances user experience with customizable UI
- Provides modern UX alignment with 2025-standard apps
- Prepares us for future "system-theme-aware" UI variations

### 🧪 Testing
- Works locally via Vite dev server
- User preference persists on refresh
- Auto-detects OS theme when no preference is set
- No backend dependencies required

Everything is working smoothly and is ready for merge 🚀
